### PR TITLE
Enhance JSON-LD cleanup and .gitignore patterns

### DIFF
--- a/.github/workflows/test-results-validation.yml
+++ b/.github/workflows/test-results-validation.yml
@@ -16,6 +16,34 @@ jobs:
       - name: 📥 Checkout System Repository
         uses: actions/checkout@v4
       
+      - name: 🧹 Clean Up Any Existing Test Results
+        run: |
+          echo "Cleaning up any existing generated JSON-LD files..."
+          
+          # Remove all test result files
+          rm -rf compliance/results
+          
+          # Remove all compliance matrix files
+          rm -rf compliance/reports
+          rm -f compliance/dashboard/compliance_matrix.jsonld
+          rm -f compliance_matrix.jsonld
+          
+          # Remove any cloud artifacts directory
+          rm -rf cloud_artifacts
+          
+          # Remove any temp directories and files
+          rm -rf temp
+          rm -rf tmp
+          
+          # Remove component temporary files
+          rm -rf components
+          
+          echo "✅ Cleanup completed. All generated JSON-LD files have been removed."
+          
+          # Verify what remains (for debugging)
+          echo "Remaining .jsonld files (only source files should be listed):"
+          find . -name "*.jsonld" | grep -v "requirements.jsonld\|requirements-context.jsonld\|test-results-template.jsonld" || echo "No unexpected .jsonld files found"
+      
       - name: 🔧 Setup jq
         run: sudo apt-get update && sudo apt-get install -y jq
       

--- a/.gitignore
+++ b/.gitignore
@@ -69,12 +69,18 @@ Thumbs.db
 dashboard.log
 .dashboard_refresh.pid
 dashboard.pid
+
+# Generated JSON-LD files
 compliance/dashboard/compliance_matrix.jsonld
-
-# Test Results
-compliance/results/**/test-results.jsonld
+compliance/results/**/*.jsonld
+compliance/reports/**/*.jsonld
 **/test-results.jsonld
+compliance_matrix.jsonld
 
-# Temporary files
+# Temporary directories and files
 temp/
+tmp/
+cloud_artifacts/
+components/
+validation_logs.txt
 .dashboard_refresh.pid


### PR DESCRIPTION
This PR enhances the cleanup process by: 1) Expanding the cleanup step in test-results-validation.yml to remove all generated JSON-LD files from various locations 2) Updating .gitignore to prevent these generated files from being tracked. This will help prevent issues with stale JSON-LD files causing validation failures.